### PR TITLE
Remove warning about new boards hub

### DIFF
--- a/.azext/changelog-cache.json
+++ b/.azext/changelog-cache.json
@@ -115,6 +115,13 @@
   ],
   "pullRequests": [
     {
+      "id": 1073407016,
+      "number": 70,
+      "submitter": "joachimdalen",
+      "title": "Remove warning about new boards hub",
+      "url": "https://github.com/joachimdalen/azdevops-auto-state/pull/70"
+    },
+    {
       "id": 1009312364,
       "number": 65,
       "submitter": "joachimdalen",

--- a/.azext/changelog-cache.json
+++ b/.azext/changelog-cache.json
@@ -1,6 +1,13 @@
 {
   "issues": [
     {
+      "id": 1091255390,
+      "number": 17,
+      "submitter": "joachimdalen",
+      "title": "Observer does not work with 'New boards hub'",
+      "url": "https://github.com/joachimdalen/azdevops-auto-state/issues/17"
+    },
+    {
       "id": 1270925483,
       "number": 57,
       "submitter": "ruksarjk",

--- a/.azext/changelog-prod.json
+++ b/.azext/changelog-prod.json
@@ -2,20 +2,17 @@
   {
     "version": "1.3.1",
     "publishDate": "2022-06-XX",
-    "sections": {
-      "knownIssues": [
-        {
-          "type": "text",
-          "content": "This extension does not properly work when having the `New boards hub` feature enabled. This is being tracked in: [Observer does not work with 'New boards hub'](https://github.com/joachimdalen/azdevops-auto-state/issues/17)"
-        }
-      ]
-    },
     "changes": [
       {
         "type": "docs",
         "description": "Add link to feature menu docs",
         "issue": 57,
         "pullRequest": 65
+      },
+      {
+        "type": "docs",
+        "description": "Remove warning about New Boards Hub",
+        "issue": 17
       }
     ],
     "modules": [

--- a/.azext/changelog-prod.json
+++ b/.azext/changelog-prod.json
@@ -12,7 +12,8 @@
       {
         "type": "docs",
         "description": "Remove warning about New Boards Hub",
-        "issue": 17
+        "issue": 17,
+        "pullRequest": 70
       }
     ],
     "modules": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,15 @@
 
 ## 1.3.1 (2022-06-XX)
 
-**💡 Known issues**
-
-This extension does not properly work when having the `New boards hub` feature enabled. This is being tracked in: [Observer does not work with 'New boards hub'](https://github.com/joachimdalen/azdevops-auto-state/issues/17)
-
----
-
-### 📝 Documentation (1)
+### 📝 Documentation (2)
 
 - Add link to feature menu docs
+
   - Changed needed [GH#57 - It's not clear how to activate the extension](https://github.com/joachimdalen/azdevops-auto-state/issues/57)
   - Changed in [PR#65 - docs: Add activation docs](https://github.com/joachimdalen/azdevops-auto-state/pull/65)
+
+- Remove warning about New Boards Hub
+  - Changed needed [GH#17 - Observer does not work with 'New boards hub'](https://github.com/joachimdalen/azdevops-auto-state/issues/17)
 
 ## 📦 Module changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Remove warning about New Boards Hub
   - Changed needed [GH#17 - Observer does not work with 'New boards hub'](https://github.com/joachimdalen/azdevops-auto-state/issues/17)
+  - Changed in [PR#70 - Remove warning about new boards hub](https://github.com/joachimdalen/azdevops-auto-state/pull/70)
 
 ## 📦 Module changes
 

--- a/README.md
+++ b/README.md
@@ -67,17 +67,6 @@
 
 ---
 
-## ⚠️ Information about the `New Boards Hub` feature
-
-This extension does not work if you have the `New Boards Hub` feature enabled. When this preview feature is enabled, certain contributions from this extension is not loaded. Microsoft says that they are "Optimizing" the feature, so all I can do is wait until this feature comes out of preview.
-
-This issue is being tracked:
-
-- [GitHub](https://github.com/joachimdalen/azdevops-auto-state/issues/17)
-- [Developer Community](https://developercommunity.visualstudio.com/t/Extension-contribution-no-longer-loads-w/1631893)
-
----
-
 ## About The Project
 
 ![Product Name Screen Shot][product-screenshot]

--- a/marketplace/raw/README.md
+++ b/marketplace/raw/README.md
@@ -25,17 +25,6 @@
 
 ---
 
-## ⚠️ Information about the `New Boards Hub` feature
-
-This extension does not work if you have the `New Boards Hub` feature enabled. When this preview feature is enabled, certain contributions from this extension is not loaded. Microsoft says that they are "Optimizing" the feature, so all I can do is wait until this feature comes out of preview.
-
-This issue is being tracked:
-
-- [GitHub](https://github.com/joachimdalen/azdevops-auto-state/issues/17)
-- [Developer Community](https://developercommunity.visualstudio.com/t/Extension-contribution-no-longer-loads-w/1631893)
-
----
-
 ## Features
 
 - Create rules to manage state transitions


### PR DESCRIPTION
A fix has been issued by the Azure Boards Teams and verified.